### PR TITLE
Replace sudo command with become

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,11 @@
   register: current_hostname
 
 - name: Ensure packages database is up to date
-  sudo: yes
+  become: yes
   apt: update_cache=yes
 
 - name: Install MySQL Packages
-  sudo: yes
+  become: yes
   apt: pkg={{ item }} state=latest
   with_items:
     - mysql-server


### PR DESCRIPTION
Issue: [phansible/phansible/issues/273](https://github.com/phansible/phansible/issues/273)
Replace `sudo` command `become`since `sudo` will be deprecated.
