### PR TITLE
Changing the default/main file to accept multiple databases and mysql dump files for issue #7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 mysql:
     root_password: root
-    database: phansible
     user: changme
     password: changme
-    dump: ""
+    databases:
+      - database: phansible
+        dump: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
     - "{{ current_hostname.stdout | lower }}"
 
 - name: Create users
-  mysql_user: name={{ mysql.user }} password={{ mysql.password }} priv={{ mysql.database }}.*:ALL state=present login_user=root login_password={{ mysql.root_password }}
+  mysql_user: name={{ mysql.user }} password={{ mysql.password }} priv={{ item.database }}.*:ALL state=present login_user=root login_password={{ mysql.root_password }}
   when: item.database is defined
   with_items:
     - "{{ mysql.databases }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,13 +26,13 @@
 
 - name: Create databases
   mysql_db: name={{ item.database }} state=present login_user=root login_password={{ mysql.root_password }}
-  when: item.database is defined
+  when: item.database
   with_items:
     - "{{ mysql.databases }}"
 
 - name: Import dump
   mysql_db: name={{ item.database }} state=import login_user=root login_password={{ mysql.root_password }} target=/vagrant/{{ item.dump }}
-  when: item.database is defined and item.dump is defined
+  when: item.database and item.dump
   with_items:
     - "{{ mysql.databases }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,11 +25,16 @@
     - localhost
 
 - name: Create databases
-  mysql_db: name={{ mysql.database }} state=present login_user=root login_password={{ mysql.root_password }}
+  mysql_db: name={{ item.database }} state=present login_user=root login_password={{ mysql.root_password }}
+  when: item.database is defined
+  with_items:
+    - "{{ mysql.databases }}"
 
 - name: Import dump
-  mysql_db: name={{ mysql.database }} state=import login_user=root login_password={{ mysql.root_password }} target=/vagrant/{{ mysql.dump }}
-  when: mysql.dump
+  mysql_db: name={{ item.database }} state=import login_user=root login_password={{ mysql.root_password }} target=/vagrant/{{ item.dump }}
+  when: item.database is defined and item.dump is defined
+  with_items:
+    - "{{ mysql.databases }}"
 
 - name: Ensure anonymous users are not in the database
   mysql_user: name='' host={{ item }} state=absent login_user=root login_password={{ mysql.root_password }}
@@ -39,3 +44,6 @@
 
 - name: Create users
   mysql_user: name={{ mysql.user }} password={{ mysql.password }} priv={{ mysql.database }}.*:ALL state=present login_user=root login_password={{ mysql.root_password }}
+  when: item.database is defined
+  with_items:
+    - "{{ mysql.databases }}"


### PR DESCRIPTION
Allows a user the ability to provide 1 or more databases and/or database import files. This will also allow a user to create multiple databases, even if each database doesn't have an import file. It will create the databases regardless and import data for the databases that need it.
